### PR TITLE
Update post_type.php to include Add New label

### DIFF
--- a/inc/post_type.php
+++ b/inc/post_type.php
@@ -18,6 +18,7 @@ function cbp_register_post_type() {
 			'labels'        => [
 				'name'          => $parts_name,
 				'singular_name' => $parts_name,
+				'add_new' 	=> __( 'Add New', 'loos_cbp' ),
 			],
 			'public'        => false,
 			// 'menu_position' => 6,


### PR DESCRIPTION
Adding the Add New label to `register_post_type` allows using a specific Add New label translation for block patterns, instead of the one used for regular posts, which is critical for several languages.